### PR TITLE
Update `function`, and add typing

### DIFF
--- a/dtyper.py
+++ b/dtyper.py
@@ -62,6 +62,7 @@ def function(typer_command: Callable[P, R]) -> Callable[P, R]:
 
     @wraps(typer_command)
     def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+        # https://docs.python.org/3/library/inspect.html#inspect.Signature.bind
         bound = new_sig.bind(*args, **kwargs)
         bound.apply_defaults()
         return typer_command(*bound.args, **bound.kwargs)

--- a/dtyper.py
+++ b/dtyper.py
@@ -1,20 +1,34 @@
-from dataclasses import make_dataclass, field
+from __future__ import annotations
+
+from dataclasses import field, make_dataclass
 from functools import wraps
-import inspect
+from inspect import Signature, signature, Parameter
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Callable, TypeVar
+
+    from typing_extensions import ParamSpec
+
+    P = ParamSpec("P")
+    R = TypeVar("R")
 
 __version__ = '0.9.0'
 
 
 @wraps(make_dataclass)
 def dataclass(typer_command, base=None, **kwargs):
-    def to_field(k, v, default):
-        return (k, v) if default is ... else (k, v, field(default=default))
 
     if base is not None:
         kwargs['bases'] = *kwargs.get('bases', ()), base
 
     kwargs.setdefault('cls_name', typer_command.__name__)
-    kwargs['fields'] = [to_field(*i) for i in _params(typer_command)]
+    kwargs['fields'] = [
+        (p.name, p.annotation)
+        if p.default is Parameter.empty
+        else (p.name, p.annotation, field(default=p.default))
+        for p in _fixed_signature(typer_command).parameters.values()
+    ]
 
     @wraps(typer_command)
     def dataclass_maker(function_or_class):
@@ -34,39 +48,35 @@ def dataclass(typer_command, base=None, **kwargs):
     return dataclass_maker
 
 
-def function(typer_command):
-    params = list(_params(typer_command))
+def function(typer_command: Callable[P, R]) -> Callable[P, R]:
+    """Return function that can be called outside of a typer.Typer app context
+
+    This allows a function with default argument values of instance `typer.Option`
+    and `typer.Argument` to be called without having to provide all the defaults
+    manually.
+    """
+
+    new_sig = _fixed_signature(typer_command)
 
     @wraps(typer_command)
-    def wrapped(*args, **kwargs):
-        tc = typer_command.__name__ + '()'
+    def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+        bound = new_sig.bind(*args, **kwargs)
+        bound.apply_defaults()
+        return typer_command(*bound.args, **bound.kwargs)
 
-        if len(args) > len(params):
-            lp = len(params)
-            s = 's' * (lp != 1)
-            la = len(args)
-            raise TypeError(f'{tc} takes {lp} argument{s} but {la} were given')
-
-        for name, _, default in params[len(args):]:
-            value = kwargs.pop(name, default)
-            if value is ...:
-                raise TypeError(f'{tc} missing required parameter \'{name}\'')
-            args = *args, value
-        return typer_command(*args, **kwargs)
-
+    wrapped.__signature__ = new_sig  # type: ignore
     return wrapped
 
 
-def _params(typer_command):
-    required = True
-    params = inspect.signature(typer_command).parameters
-    for name, param in params.items():
-        t = param.annotation or 'typing.Any'
-        default = param.default.default
+def _fixed_signature(typer_command: Callable[P, R]) -> Signature:
+    """Return `inspect.Signature` with fixed default values for typer objects."""
+    sig = signature(typer_command)
 
-        if default is not ...:
-            required = False
-        elif not required:
-            raise ValueError('Required value after optional')
+    fixed_parameters = []
+    for param in sig.parameters.values():
+        new_default = getattr(param.default, "default", param.default)
+        if new_default is Ellipsis:
+            new_default = Parameter.empty
+        fixed_parameters.append(param.replace(default=new_default))
 
-        yield name, t, default
+    return sig.replace(parameters=fixed_parameters)

--- a/test_dtyper.py
+++ b/test_dtyper.py
@@ -45,16 +45,13 @@ def test_bad_default():
 
 
 def test_args():
-    match = r"simple_command\(\) got an unexpected keyword argument 'frog'"
-    with pytest.raises(TypeError, match=match):
+    with pytest.raises(TypeError, match="unexpected keyword argument 'frog'"):
         simple_command('bukket', frog=30)
 
-    match = r'simple_command\(\) takes 3 arguments but 4 were given'
-    with pytest.raises(TypeError, match=match):
+    with pytest.raises(TypeError, match='too many positional arguments'):
         simple_command('bukket', 'key', 12, 30)
 
-    match = r"simple_command\(\) missing required parameter 'bucket'"
-    with pytest.raises(TypeError, match=match):
+    with pytest.raises(TypeError, match="missing a required argument: 'bucket'"):
         simple_command()
 
 


### PR DESCRIPTION
closes #1 

Had to change the tests slightly, since the error message returned from `Signature.bind()` didn't quite match the custom error messages from before (they do match the standard errors you would get if you called a regular function incorrectly though)