### PR TITLE
dtyper doesn't handle required options without a default value

### DIFF
--- a/test_dtyper.py
+++ b/test_dtyper.py
@@ -179,3 +179,20 @@ def test_less_simple_command():
 def test_less_simple_command_error():
     with pytest.raises(TypeError):
         less_simple_command('bukket', pid=3)
+
+
+@dtyper.function
+@command(help='test')
+def required_option_without_default_command(
+    bucket: str = Argument(..., help='The bucket to use'),
+    keys: str = Argument('keys', help='The keys to download'),
+    pid: Optional[int] = Option(..., help='pid'),
+    verbose: Optional[int] = Option(
+        True,
+    ),
+):
+    return bucket, keys, pid, verbose
+
+
+def test_required_option_without_default():
+    # TODO Test for Arguements and Options in the right sections of help


### PR DESCRIPTION
Hello! I thought it'd be easier to explain the issue with a test.

```
Usage: required_option_without_default_command [OPTIONS] bucket keys

Arguments
*    bucket             TEXT  [default: None] [required] 
*    keys              TEXT  [default: keys] [required] 

Options 
--pid                   TEXT             [default: None]
--verbose               BOOL             [default: True]
--help                                   Show this message and exit.
```

I'd expect an output like this if there's no `@dtyper.function` decorator, but instead the `PID` option would show up in the arguments section
