### PR TITLE
Fix `__all__` & improve `command` signature

### DIFF
--- a/dtyper.py
+++ b/dtyper.py
@@ -192,7 +192,7 @@ Some of the code is offloaded to helper files like `helper.py`:
 
 from __future__ import annotations
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING
 import inspect
 import typer
 from typer import (
@@ -243,7 +243,7 @@ except ImportError:
     from dataclasses import field, make_dataclass
 
 if TYPE_CHECKING:
-    from typing import Callable, Optional, Type, TypeVar, Union
+    from typing import Callable, Optional, Type, TypeVar, Union, Dict, Any
 
     from typing_extensions import ParamSpec
 


### PR DESCRIPTION
not as fancy as the dynamic construction of `__all__` but Pyright was complaining that the members aren't exported and this is not supported for dunder attributes
also wasn't able to get completion results for the `@app.command` decorator, so I expanded the `*args, **kwargs` in the signature
