### PR TITLE
Fix missing `self` argument for `@app.command` decorator

### DIFF
--- a/dtyper.py
+++ b/dtyper.py
@@ -380,7 +380,6 @@ class Typer(typer.Typer):
     above so they can be called from regular Python code.
     """
 
-    @wraps(typer.Typer.command)
     def command(
         self,
         name: Optional[str] = None,


### PR DESCRIPTION
Fixes #8

I believe the outer `@wraps` decorator is unnecessary since it's already inheriting from `typer.Typer`